### PR TITLE
Upgrade to Flutter 2.2.0

### DIFF
--- a/lib/rich_text_controller.dart
+++ b/lib/rich_text_controller.dart
@@ -35,7 +35,7 @@ class RichTextController extends TextEditingController {
         super.fromValue(value);
 
   @override
-  TextSpan buildTextSpan({TextStyle? style, required bool withComposing}) {
+  TextSpan buildTextSpan({required BuildContext context, TextStyle? style, required bool withComposing}) {
     List<TextSpan> children = [];
     List<String> matches = [];
     // Validating with REGEX


### PR DESCRIPTION
In Flutter 2.2 `buildTextSpan`'s signature has been changed.
This PR addresses this change.