### PR TITLE
Exposing RegExp options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ See Example page for example code.
 | **Map<String, TextStyle>** stringMatchMap          | Map to match a certain word with a custom style           | **--**    |
 | **@required Function(List<String> match)** onMatch | Void Callback for matched content                         | **--**    |
 | **bool** deleteOnBack                              | delete the last matched content on backspace or not       | **false** |
+| **bool** regExpCaseSensitive                       | control the caseSensitive parameter of the used [RegExp]  | **true** |
+| **bool** regExpDotAll                              | control the dotAll parameter of the used [RegExp]         | **false** |
+| **bool** regExpMultiLine                           | control the multiLine parameter of the used [RegExp]      | **false** |
+| **bool** regExpUnicode                             | control the unicode parameter of the used [RegExp]        | **false** |
 
 ### Assertions
 

--- a/example/README.md
+++ b/example/README.md
@@ -64,6 +64,8 @@ RichTextController _controller;
            // as long as you're typing, the controller will keep updating the list.
          }
          deleteOnBack: true,
+         // You can control the [RegExp] options used:
+         regExpUnicode: true,
 
       );
     super.initState();

--- a/lib/rich_text_controller.dart
+++ b/lib/rich_text_controller.dart
@@ -21,7 +21,8 @@ import 'package:flutter/widgets.dart';
 ///         RegExp(r"\B@[a-zA-Z0-9]+\b"): const TextStyle(
 ///           fontWeight: FontWeight.w800,
 ///           color: Colors.blue,
-///         ),
+///         },
+/// );
 ///
 ///  TextFormField(
 ///  controller: _controller,

--- a/lib/rich_text_controller.dart
+++ b/lib/rich_text_controller.dart
@@ -21,7 +21,9 @@ import 'package:flutter/widgets.dart';
 ///         RegExp(r"\B@[a-zA-Z0-9]+\b"): const TextStyle(
 ///           fontWeight: FontWeight.w800,
 ///           color: Colors.blue,
-///         },
+///         ),
+///       },
+///       regExpCaseSensitive: false,
 /// );
 ///
 ///  TextFormField(
@@ -38,6 +40,15 @@ class RichTextController extends TextEditingController {
   final bool? deleteOnBack;
   String _lastValue = "";
 
+  /// controls the caseSensitive property of the full [RegExp] used to pattern match
+  final bool regExpCaseSensitive;
+  /// controls the dotAll property of the full [RegExp] used to pattern match
+  final bool regExpDotAll;
+  /// controls the multiLine property of the full [RegExp] used to pattern match
+  final bool regExpMultiLine;
+  /// controls the unicode property of the full [RegExp] used to pattern match
+  final bool regExpUnicode;
+
   bool isBack(String current, String last) {
     return current.length < last.length;
   }
@@ -48,6 +59,10 @@ class RichTextController extends TextEditingController {
     this.stringMatchMap,
     required this.onMatch,
     this.deleteOnBack = false,
+    this.regExpCaseSensitive = true,
+    this.regExpDotAll = false,
+    this.regExpMultiLine = false, 
+    this.regExpUnicode = false
   })  : assert((patternMatchMap != null && stringMatchMap == null) ||
             (patternMatchMap == null && stringMatchMap != null)),
         super(text: text);
@@ -63,12 +78,24 @@ class RichTextController extends TextEditingController {
     // Validating with REGEX
     RegExp? allRegex;
     allRegex = patternMatchMap != null
-        ? RegExp(patternMatchMap?.keys.map((e) => e.pattern).join('|') ?? "")
+        ? RegExp(
+          patternMatchMap?.keys.map((e) => e.pattern).join('|') ?? "", 
+          caseSensitive: regExpCaseSensitive,
+          dotAll: regExpDotAll,
+          multiLine: regExpMultiLine,
+          unicode: regExpUnicode
+        )
         : null;
     // Validating with Strings
     RegExp? stringRegex;
     stringRegex = stringMatchMap != null
-        ? RegExp(r'\b' + stringMatchMap!.keys.join('|').toString() + r'+\b')
+        ? RegExp(
+          r'\b' + stringMatchMap!.keys.join('|').toString() + r'+\b',
+          caseSensitive: regExpCaseSensitive,
+          dotAll: regExpDotAll,
+          multiLine: regExpMultiLine,
+          unicode: regExpUnicode
+        )
         : null;
     ////
     text.splitMapJoin(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -67,6 +67,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -127,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rich_text_controller
 description: An extended text editing controller that supports different inline styles for custom regex patterns
-version: 1.4.0
+version: 1.4.1
 homepage: https://github.com/micazi/rich_text_controller
 
 environment:


### PR DESCRIPTION
The PR exposes all options for the RegExp used to match styling parts. This way, although the individual RegExp configurations are still ignored, they can at least be set for all at the same time.

This provides an easy way out of these two issues:

- https://github.com/micazi/rich_text_controller/issues/6
- https://github.com/micazi/rich_text_controller/issues/21